### PR TITLE
Support Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bloodeagle40234/statsd
+module github.com/bloodeagle40234/statsd/v2
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bloodeagle40234/statsd
+
+go 1.12


### PR DESCRIPTION
We need go.mod to maintain the repo as go module compatible.
And unfortunately this repo already has v2.0.0 at the fork so that we need to start from v2 to be as >v2.0.0. otherwise go module finds older v2.0.0 as incompatible.