### PR TITLE
Fix unit test for UDP client, update go.mod, go.sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ client.
 See the [benchmark](https://github.com/alexcesaro/statsdbench) for a comparison
 with other Go StatsD clients.
 
+## Changes from the original version
+The sole change from the original project from alexcesaro, is that we do not test if the server
+is listening, when creating a UDP client.
+
 ## Features
 
 - Supports all StatsD metrics: counter, gauge, timing and set

--- a/examples_test.go
+++ b/examples_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"gopkg.in/alexcesaro/statsd.v2"
+	"github.com/alecuyer/statsd/v2"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/alecuyer/statsd/v2
+module github.com/alecuyer/statsd
 
 go 1.12
+
+require github.com/alecuyer/statsd/v2 v2.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/alecuyer/statsd/v2 v2.0.4 h1:FS5ikragRLzL7ko3XAkNNbN8TFbQhexVfX6tO1UvdvM=
+github.com/alecuyer/statsd/v2 v2.0.4/go.mod h1:qNFEkL4GN8jGsZpfrn9P6Q0FfdJf1b1FEGpWnesU4dc=

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -359,16 +359,15 @@ func TestConcurrency(t *testing.T) {
 	})
 }
 
+// We expect to be able to create a client, even if the server is not listening
 func TestUDPNotListening(t *testing.T) {
 	dialTimeout = mockUDPClosed
 	defer func() { dialTimeout = net.DialTimeout }()
 
-	c, err := New()
-	if c == nil || !c.muted {
-		t.Error("New() did not return a muted client")
-	}
-	if err == nil {
-		t.Error("New should return an error")
+	_, err := New()
+
+	if err != nil {
+		t.Fatalf("New: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fix unit test when the UDP server is not listening: we expect the client
creation to suceeed.
Add a note about it in README.md